### PR TITLE
Changed so sensor is listening to topic 'pBv1.0/flood_sensors/DCMD' i…

### DIFF
--- a/deploy/boot.py
+++ b/deploy/boot.py
@@ -4,31 +4,31 @@ import os
 import time
 import ubinascii
 from DEVICE_CONFIG import SSID,PASSWORD,DEVICE_NAME
-l="1.0"
+k="1.0"
 gc.collect()
 def do_connect():
  import network
- V=network.WLAN(network.AP_IF)
- V.active(False)
- N=network.WLAN(network.STA_IF)
- N.active(True)
- v=N.config("mac")
- print("\nMAC Address:",ubinascii.hexlify(v).decode())
- if not N.isconnected():
+ B=network.WLAN(network.AP_IF)
+ B.active(False)
+ p=network.WLAN(network.STA_IF)
+ p.active(True)
+ V=p.config("mac")
+ print("\nMAC Address:",ubinascii.hexlify(V).decode())
+ if not p.isconnected():
   print("\nConnecting to network...")
   print("Connecting to SSID:",SSID)
-  N.connect(SSID,PASSWORD)
-  S=0
-  while not N.isconnected():
+  p.connect(SSID,PASSWORD)
+  u=0
+  while not p.isconnected():
    time.sleep(5)
-   S+=5
-   print("Waiting for connection... ",S,"seconds") 
-   if S>30:
+   u+=5
+   print("Waiting for connection... ",u,"seconds") 
+   if u>30:
     print("Connection failed. Rebooting...")
     machine.reset()
    pass
- print("\nnetwork config:",N.ifconfig())
- print("\nMAC Address:",ubinascii.hexlify(v).decode())
+ print("\nnetwork config:",p.ifconfig())
+ print("\nMAC Address:",ubinascii.hexlify(V).decode())
  print("Connecting to SSID:",SSID)
 print("\n\n\nSensor Booting Up...")
 print("\nmircopython version:",os.uname())

--- a/deploy/install_to_device.sh
+++ b/deploy/install_to_device.sh
@@ -1,5 +1,8 @@
 echo copying DEVICE_CONFIG.py
-sudo ampy -p /dev/tty.usbserial-1410 -b 115200 put DEVICE_CONFIG.py
+sudo ampy -p /dev/tty.usbserial-1410 -b 115200 put ../src/DEVICE_CONFIG.py
+echo done
+echo copying HW_CONFIG.py
+sudo ampy -p /dev/tty.usbserial-1410 -b 115200 put ../src/HW_CONFIG.py
 echo done
 echo copying main_mqtt2.py
 sudo ampy -p /dev/tty.usbserial-1410 -b 115200 put main.py

--- a/deploy/main.py
+++ b/deploy/main.py
@@ -6,99 +6,99 @@ from umqtt.simple import MQTTClient
 import ubinascii
 import machine
 import json
-f="1.0"
-r=5
-n="pBv1.0/flood_sensors"
-E="pBv1.0/flood_sensors/DCMD"
-h="pBv1.0/flood_sensors/DDATA/"+DEVICE_LOCATION+"/"+DEVICE_NAME
+P="1.0"
+f=5
+G="spBv1.0/flood_sensors"
+j="spBv1.0/flood_sensors/DCMD"
+S="spBv1.0/flood_sensors/DDATA/"+DEVICE_LOCATION+"/"+DEVICE_NAME
 if ANALOG_SENSOR_PIN!="":
  from machine import ADC
- I=ADC(ANALOG_SENSOR_PIN)
+ R=ADC(ANALOG_SENSOR_PIN)
 else:
- I=""
+ R=""
 if DIGITAL_SENSOR_PIN!="":
  from machine import Pin
- s=Pin(DIGITAL_SENSOR_PIN,Pin.IN,Pin.PULL_UP)
+ g=Pin(DIGITAL_SENSOR_PIN,Pin.IN,Pin.PULL_UP)
 else:
- s=""
-c=mqtt_broker_address
-p=ubinascii.hexlify(DEVICE_NAME)
-X=b'pBv1.0/flood_sensors/DCMD'
-D=b'pBv1.0/flood_sensors/DDATA/'+DEVICE_LOCATION+'/'+DEVICE_NAME
-print(D)
-Y=0
-x=MQTT_PUBLISH_INTERVAL
+ g=""
+s=mqtt_broker_address
+u=ubinascii.hexlify(DEVICE_NAME)
+V=b'spBv1.0/flood_sensors/DCMD'
+W=b'spBv1.0/flood_sensors/DDATA/'+DEVICE_LOCATION+'/'+DEVICE_NAME
+print(W)
+E=0
+w=MQTT_PUBLISH_INTERVAL
 def sub_cb(topic,msg):
  print((topic,msg))
- if topic==b'pBv1.0/flood_sensors/DCMD':
+ if topic==b'spBv1.0/flood_sensors/DCMD':
   print('ESP received DCMD message')
-  C="\"name\":\"OTA\""
-  w="\"name\":\"status\""
-  d="\"deviceName\":\""+DEVICE_NAME+"\""
-  l="\"deviceName\":\"*\"" 
-  R=msg.decode()
-  if C in R and(d in R or l in R):
+  t="\"name\":\"OTA\""
+  p="\"name\":\"status\""
+  A="\"deviceName\":\""+DEVICE_NAME+"\""
+  Q="\"deviceName\":\"*\"" 
+  b=msg.decode()
+  if t in b and(A in b or Q in b):
    print('ESP received CMD message: OTA')
-   P=json.loads(R)
+   N=json.loads(b)
    from ota import OTAUpdater
-   T="https://raw.githubusercontent.com/learnbanjo/flood-sensor/refs/heads/deploy-test/deploy/"
-   v=P.get("otafiles")
-   U=True
-   R=DEVICE_NAME+" OTA: "+v
+   l="https://raw.githubusercontent.com/learnbanjo/flood-sensor/refs/heads/deploy-test/deploy/"
+   i=N.get("otafiles")
+   n=True
+   b=DEVICE_NAME+" OTA: "+i
    try:
-    W=OTAUpdater(T,v)
-    if W.check_for_updates():
-     if W.download_and_install_update():
-      R+=" updated"
+    C=OTAUpdater(l,i)
+    if C.check_for_updates():
+     if C.download_and_install_update():
+      b+=" updated"
      else:
-      R+=" update failed"
+      b+=" update failed"
     else:
-     R+=" up-to-date" 
-     U=False
-   except Exception as O:
-    R+=" err:"+str(O)+" type:"+str(type(O))
+     b+=" up-to-date" 
+     n=False
+   except Exception as F:
+    b+=" err:"+str(F)+" type:"+str(type(F))
    finally:
-    print(R)
-    K.publish(h,R)
+    print(b)
+    r.publish(S,b)
     time.sleep(5)
-    if U:
+    if n:
      machine.reset() 
-  elif w in R:
+  elif p in b:
    print('ESP received CMD message: status')
-   K.publish(D,create_sensor_message())
+   r.publish(W,create_sensor_message())
 def connect_and_subscribe():
- global p,c,X
- K=MQTTClient(p,c)
- K.set_callback(sub_cb)
- K.connect()
- K.subscribe(X)
- print('Connected to %s MQTT broker, subscribed to %s topic'%(c,X))
- return K
+ global u,s,V
+ r=MQTTClient(u,s)
+ r.set_callback(sub_cb)
+ r.connect()
+ r.subscribe(V)
+ print('Connected to %s MQTT broker, subscribed to %s topic'%(s,V))
+ return r
 def restart_and_reconnect():
  print('Failed to connect to MQTT broker. Reconnecting...')
  time.sleep(10)
  machine.reset()
 def create_sensor_message(error=""):
- global I
- global s
- R="{\"devNm\":\""+DEVICE_NAME+"\",\"devTy\":\""+DEVICE_TYPE+"\",\"AP\":\""+SSID+"\""
- if(I!=""):
-  R=R+",\"AnaR\":\""+str(I.read())+"\""
- if(s!=""):
-  R=R+",\"DigR\":\""+str(s.value())+"\""
+ global R
+ global g
+ b="{\"devNm\":\""+DEVICE_NAME+"\",\"devTy\":\""+DEVICE_TYPE+"\",\"AP\":\""+SSID+"\""
+ if(R!=""):
+  b=b+",\"AnaR\":\""+str(R.read())+"\""
+ if(g!=""):
+  b=b+",\"DigR\":\""+str(g.value())+"\""
  if error!="":
-  R=R+",\"err\":\""+error+"\""
- return R+"}"
+  b=b+",\"err\":\""+error+"\""
+ return b+"}"
 try:
- K=connect_and_subscribe()
+ r=connect_and_subscribe()
 except OSError as e:
  restart_and_reconnect()
 while True:
  try:
-  K.check_msg()
-  if(time.time()-Y)>x:
-   K.publish(D,create_sensor_message())
-   Y=time.time()
+  r.check_msg()
+  if(time.time()-E)>w:
+   r.publish(W,create_sensor_message())
+   E=time.time()
  except OSError as e:
   restart_and_reconnect()
 # Created by pyminifier (https://github.com/liftoff/pyminifier)

--- a/deploy/ota-test.sh
+++ b/deploy/ota-test.sh
@@ -1,0 +1,16 @@
+#scipt for ota testing
+#this should be run in Python 2 environment
+
+counter=0
+
+while [ $counter -lt 100 ]
+do
+    echo "OTA Test Counter: $counter"
+    ((counter++))
+    source update_minmize_code.sh
+    ls -al *.py
+    git add boot.py main.py ota.py utils.py 
+    git commit -m "ota test $counter, re-minimize only, no code change"
+    git push origin deploy-test
+    sleep 300
+done

--- a/deploy/ota.py
+++ b/deploy/ota.py
@@ -2,68 +2,74 @@ import urequests
 import os
 import gc
 import json
-i="1.0"
+f="1.0"
 class OTAUpdater:
- def __init__(W,Q,M):
-  W.filename=M
-  W.repo_url=Q
-  W.version_file=M+'_'+'ver.json'
-  W.version_url=W.process_version_url(Q,M) 
-  W.firmware_url=Q+M 
-  if W.version_file in os.listdir():
-   with open(W.version_file)as f:
-    W.current_version=json.load(f)['version']
+ def __init__(G,h,n):
+  G.filename=n
+  G.repo_url=h
+  G.version_file=n+'_'+'ver.json'
+  G.version_url=G.process_version_url(h,n) 
+  G.firmware_url=h+n 
+  print("Version URL is ",G.version_url)
+  print("Firmware URL is ",G.firmware_url)
+  if G.version_file in os.listdir():
+   with open(G.version_file)as f:
+    G.current_version=json.load(f)['version']
+   k="Current "+G.filename+" is "+G.current_version
+   print("version message ",k)
   else:
-   W.current_version="0"
-   with open(W.version_file,'w')as f:
-    json.dump({'version':W.current_version},f)
- def process_version_url(W,Q,M):
-  N=Q.replace("raw.githubusercontent.com","github.com") 
-  N=N.replace("/","§",4) 
-  N=N.replace("/","/latest-commit/",1) 
-  N=N.replace("§","/",4) 
-  N=N+M 
-  return N
- def fetch_latest_code(W)->bool:
-  u=urequests.get(W.firmware_url,timeout=20)
-  if u.status_code==200:
+   print("No version file")
+   G.current_version="0"
+   with open(G.version_file,'w')as f:
+    json.dump({'version':G.current_version},f)
+ def process_version_url(G,h,n):
+  a=h.replace("raw.githubusercontent.com","github.com") 
+  a=a.replace("/","§",4) 
+  a=a.replace("/","/latest-commit/",1) 
+  a=a.replace("§","/",4) 
+  a=a+n 
+  return a
+ def fetch_latest_code(G)->bool:
+  x=urequests.get(G.firmware_url,timeout=20)
+  if x.status_code==200:
    gc.collect()
    try:
-    W.latest_code=u.text
+    G.latest_code=x.text
     return True
    except Exception as e:
     print('Failed to fetch latest code:',e)
     return False
-  elif u.status_code==404:
+  elif x.status_code==404:
    print('Firmware not found.')
    return False
- def update_no_reset(W):
+ def update_no_reset(G):
   with open('latest_code.py','w')as f:
-   f.write(W.latest_code)
-  W.current_version=W.latest_version
-  with open(W.version_file,'w')as f:
-   json.dump({'version':W.current_version},f)
-  W.latest_code=None
-  os.rename('latest_code.py',W.filename)
- def check_for_updates(W):
+   f.write(G.latest_code)
+  G.current_version=G.latest_version
+  with open(G.version_file,'w')as f:
+   json.dump({'version':G.current_version},f)
+  G.latest_code=None
+  os.rename('latest_code.py',G.filename)
+ def check_for_updates(G):
+  print('Checking for latest version...')
   gc.collect()
-  H={"accept":"application/json"}
-  u=urequests.get(W.version_url,headers=H,timeout=5)
-  Y=json.loads(u.text)
-  W.latest_version=Y['oid'] 
-  x=True if W.current_version!=W.latest_version else False
-  p="New ver: "+str(x)
-  print(p) 
-  return x
- def download_and_install_update_if_available(W):
-  if W.check_for_updates():
-   return W.download_and_install_update()
+  g={"accept":"application/json"}
+  x=urequests.get(G.version_url,headers=g,timeout=5)
+  J=json.loads(x.text)
+  G.latest_version=J['oid'] 
+  C=True if G.current_version!=G.latest_version else False
+  O="New ver: "+str(C)
+  print(O) 
+  return C
+ def download_and_install_update_if_available(G):
+  if G.check_for_updates():
+   return G.download_and_install_update()
   else:
    print('No new updates available.')
    return True
- def download_and_install_update(W):
-  if W.fetch_latest_code():
-   W.update_no_reset()
+ def download_and_install_update(G):
+  if G.fetch_latest_code():
+   G.update_no_reset()
   else:
    return False
   return True

--- a/deploy/update_no-minimize_code.sh
+++ b/deploy/update_no-minimize_code.sh
@@ -1,0 +1,15 @@
+#this should be run in Python 2 environment
+#since pyminifier is not supported in Python 3
+
+echo copying main_mqtt2.py
+cp ../src/main_mqtt2.py  main.py
+echo done
+echo copying ota.py
+cp ../src/ota.py ota.py
+echo done
+echo copying utils.py
+cp ../src/utils.py  utils.py
+echo done
+echo copying boot.py
+cp ../src/boot.py  boot.py
+echo done

--- a/deploy/utils.py
+++ b/deploy/utils.py
@@ -1,13 +1,13 @@
-p="1.0"
+V="1.0"
 import gc
 def qs_parse(qs):
- A={}
- g=qs.split("&")
- for i in g:
-  V=i.split("=")
-  if len(V)==2:
-   A[V[0]]=V[1]
- return A
+ c={}
+ v=qs.split("&")
+ for H in v:
+  k=H.split("=")
+  if len(k)==2:
+   c[k[0]]=k[1]
+ return c
 def free(full=False):
  gc.collect()
  F=gc.mem_free()

--- a/src/DEVICE_CONFIG_template.py
+++ b/src/DEVICE_CONFIG_template.py
@@ -1,12 +1,12 @@
-DEVICE_NAME = "device host name" # Descriptive name for the device
-DEVICE_TYPE = "Flood Sensor" # Sensor Type. "Flood Sensor", "Pressure Sensor"
+DEVICE_NAME = "FS_bh_basement" # Descriptive name for the device
+DEVICE_TYPE = "flood_sensor" # Sensor Type. "Flood Sensor", "Pressure Sensor"
 DEVICE_KEY = "" #device private key for future use cases
+SPARKPLUGB_GID = "flood_sensor"  # Sparkplug B Group ID, usually is device type
+SPARKPLUGB_EONID = "bh" # Sparkplug B Edge of Network ID, usually is building name
 SSID = "my wifi hotspot name"
 PASSWORD = "wifi password" #Use "" for no password
-ANALOG_SENSOR_PIN = 0 # ESP8266 ADC pin is 0. Set to "" to disable
-DIGITAL_SENSOR_PIN = 5 # ESP8266 GPIO pin is D1 (GPIO5). Set to "" to disable. See https://electropeak.com/learn/esp8266-pinout-reference-how-to-use-esp8266-gpio-pins/
 
-MQTT_PUBLISH_INTERVAL = 30
-mqtt_broker_address = "127.0.0.1"
-mqtt_broker_port = 1883
-mqtt_keep_alive_time = 360
+MQTT_PUBLISH_INTERVAL = 300
+MQTT_BROKER_ADD = "127.0.0.1"
+MQTT_BROKER_PORT = 1883
+MQTT_KEEP_ALIVE_TIME = 360

--- a/src/HW_CONFIG_template.py
+++ b/src/HW_CONFIG_template.py
@@ -1,0 +1,3 @@
+ANALOG_SENSOR_PIN = 0 # ESP8266 ADC pin is 0. Set to "" to disable
+DIGITAL_SENSOR_PIN = 5 # ESP8266 GPIO pin is D1 (GPIO5). Set to "" to disable. See https://electropeak.com/learn/esp8266-pinout-reference-how-to-use-esp8266-gpio-pins/
+# Unmodified ESP8266 flood sensors use D8 (GPIO5). The flood sensor needs to be dipped in water to boot properly when connecting to a computer

--- a/src/main_mqtt2.py
+++ b/src/main_mqtt2.py
@@ -12,9 +12,9 @@ VERSION = "1.0"
 MQTT_CHECK_INTERVAL = 5
 
 # Define topics
-GenericSensorReportTopic = "pBv1.0/flood_sensors"
-OTARequestTopic = "pBv1.0/flood_sensors/DCMD"
-OTAResponseTopic = "pBv1.0/flood_sensors/DDATA/" + DEVICE_LOCATION + "/" + DEVICE_NAME
+GenericSensorReportTopic = "spBv1.0/flood_sensors"
+OTARequestTopic = "spBv1.0/flood_sensors/DCMD"
+OTAResponseTopic = "spBv1.0/flood_sensors/DDATA/" + DEVICE_LOCATION + "/" + DEVICE_NAME
 
 
 if ANALOG_SENSOR_PIN != "":
@@ -32,15 +32,15 @@ else:
 mqtt_server = mqtt_broker_address
 
 client_id = ubinascii.hexlify(DEVICE_NAME)
-topic_sub = b'pBv1.0/flood_sensors/DCMD'
-topic_pub = b'pBv1.0/flood_sensors/DDATA/' + DEVICE_LOCATION + '/' + DEVICE_NAME
+topic_sub = b'spBv1.0/flood_sensors/DCMD'
+topic_pub = b'spBv1.0/flood_sensors/DDATA/' + DEVICE_LOCATION + '/' + DEVICE_NAME
 print (topic_pub)
 last_message = 0
 message_interval = MQTT_PUBLISH_INTERVAL
 
 def sub_cb(topic, msg):
   print((topic, msg))
-  if topic == b'pBv1.0/flood_sensors/DCMD':
+  if topic == b'spBv1.0/flood_sensors/DCMD':
     print('ESP received DCMD message')
     cmdOTAString = "\"name\":\"OTA\""
     cmdStatusString = "\"name\":\"status\""

--- a/src/main_mqtt2.py
+++ b/src/main_mqtt2.py
@@ -1,98 +1,109 @@
-from DEVICE_CONFIG import DEVICE_NAME, DEVICE_TYPE, SSID, DEVICE_LOCATION
-from DEVICE_CONFIG import ANALOG_SENSOR_PIN, DIGITAL_SENSOR_PIN
-from DEVICE_CONFIG import mqtt_broker_address, mqtt_broker_port, mqtt_keep_alive_time, MQTT_PUBLISH_INTERVAL
+from DEVICE_CONFIG import DEVICE_NAME, DEVICE_TYPE, SSID
+from DEVICE_CONFIG import MQTT_BROKER_ADD, MQTT_PUBLISH_INTERVAL, SPARKPLUGB_GID, SPARKPLUGB_EONID
+from HW_CONFIG import ANALOG_SENSOR_PIN, DIGITAL_SENSOR_PIN
+from utils import get_epoch_time
 
+import json
+import machine
 import time
 from umqtt.simple import MQTTClient
-import ubinascii
-import machine
-import json
 
 VERSION = "1.0"
-MQTT_CHECK_INTERVAL = 5
 
 # Define topics
-GenericSensorReportTopic = "spBv1.0/flood_sensors"
-OTARequestTopic = "spBv1.0/flood_sensors/DCMD"
-OTAResponseTopic = "spBv1.0/flood_sensors/DDATA/" + DEVICE_LOCATION + "/" + DEVICE_NAME
+SPARKPLUGB_GP_TOPIC = "spBv1.0/" + SPARKPLUGB_GID
+SPARKPLUGB_CMD_TOPIC = SPARKPLUGB_GP_TOPIC + "/DCMD"
+SPARKPLUGB_DATA_TOPIC = SPARKPLUGB_GP_TOPIC + "/DDATA/" + SPARKPLUGB_EONID + "/" + DEVICE_NAME
+SPARKPLUGB_BIRTHTH_TOPIC = SPARKPLUGB_GP_TOPIC + "/DBIRTH/" + SPARKPLUGB_EONID + "/" + DEVICE_NAME
+SPARKPLUGB_DEATH_TOPIC = SPARKPLUGB_GP_TOPIC + "/DDEATH/" + SPARKPLUGB_EONID + "/" + DEVICE_NAME
 
+MQTT_CHECK_INTERVAL = 5
+#DDEATH REASON CODE
+DDEATH_REASON_UNKNOWN = -1    # -1: unknown. Sent via last will
+DDEATH_REASON_DCMD_REBOOT = 1 #  1: DCMD reboot command
+DDEATH_REASON_OTA = 2 #  2: OTA reboot
 
-if ANALOG_SENSOR_PIN != "":
-    from machine import ADC
-    analogSensor = ADC(ANALOG_SENSOR_PIN)
-else:
-    analogSensor = ""
+client_id_b = DEVICE_NAME.encode()
+device_id_attribute = ", \"device_id\": \"" + DEVICE_NAME + "\""
+topic_cmd_b = SPARKPLUGB_CMD_TOPIC.encode()
+topic_pub_b = SPARKPLUGB_DATA_TOPIC.encode()
+sparkplug_seq = 0
+#print (topic_cmd_b)
+#print (topic_pub_b)
 
-if DIGITAL_SENSOR_PIN != "":
-    from machine import Pin
-    digitalSensor = Pin(DIGITAL_SENSOR_PIN, Pin.IN, Pin.PULL_UP)
-else:
-    digitalSensor = ""
-
-mqtt_server = mqtt_broker_address
-
-client_id = ubinascii.hexlify(DEVICE_NAME)
-topic_sub = b'spBv1.0/flood_sensors/DCMD'
-topic_pub = b'spBv1.0/flood_sensors/DDATA/' + DEVICE_LOCATION + '/' + DEVICE_NAME
-print (topic_pub)
-last_message = 0
-message_interval = MQTT_PUBLISH_INTERVAL
+def reboot_with_reason(client, reason = 0):
+    message = get_sparkplug_prefx() + ",\"ddeath_reasons\": \"" + str(reason) + "\"}"
+    client.publish(SPARKPLUGB_DEATH_TOPIC.encode(), message.encode)
+    client.disconnect()
+    time.sleep(5)
+    machine.reset()  # Reset the device to run the new code.
+       
+def get_sparkplug_prefx():
+    global sparkplug_seq
+    if sparkplug_seq >= 2147483647:
+        sparkplug_seq = 0
+    sparkplug_seq += 1
+    
+    return "{\"timestamp: \"" + str(get_epoch_time()) + device_id_attribute + ",\"seq\": \"" + str(sparkplug_seq) + "\""
 
 def sub_cb(topic, msg):
-  print((topic, msg))
-  if topic == b'spBv1.0/flood_sensors/DCMD':
-    print('ESP received DCMD message')
-    cmdOTAString = "\"name\":\"OTA\""
-    cmdStatusString = "\"name\":\"status\""
+  #print((topic, msg))
+  if topic == topic_cmd_b:
+    #print('ESP received DCMD message')
     # typeString = "\"deviceType\":\"" + DEVICE_TYPE + "\""
-    nameString = "\"deviceName\":\"" + DEVICE_NAME + "\""
-    allString = "\"deviceName\":\"*\"" 
+    nameString = "\"device_id\":\"" + DEVICE_NAME + "\""
     message = msg.decode()
 
-    if cmdOTAString in message and (nameString in message or allString in message):
-        print('ESP received CMD message: OTA')
-        data = json.loads(message)
-        from ota import OTAUpdater
-        firmware_url = "https://raw.githubusercontent.com/learnbanjo/flood-sensor/refs/heads/deploy-test/deploy/"
-        otafile = data.get("otafiles")
-        rebootneeded = True
-        message = DEVICE_NAME + " OTA: " + otafile
-        try:
-            ota_updater = OTAUpdater(firmware_url, otafile)
-            if ota_updater.check_for_updates():
-                if ota_updater.download_and_install_update():
-                   message += " updated"
-                else:
-                   message += " update failed"
-            else:
-                message += " up-to-date"        
-                rebootneeded = False
-        except Exception as err:
-            message += " err:" + str(err) + " type:" + str(type(err))
-        
-        finally:
-            print(message)
-            client.publish(OTAResponseTopic, message)
-            time.sleep(5)
-            if rebootneeded:
-                machine.reset()  # Reset the device to run the new code.
-    elif cmdStatusString in message:
-        print('ESP received CMD message: status')
-        client.publish(topic_pub, create_sensor_message())
-
-
+    if (nameString in message or "\"device_id\":\"*\"" in message):
+      if "\"cmdID\":\"OTA\"" in message:
+          #print('ESP received CMD message: OTA')
+          data = json.loads(message)
+          #print('data:', data)
+          from ota import OTAUpdater
+          firmware_url = "https://raw.githubusercontent.com/learnbanjo/flood-sensor/refs/heads/deploy-test/deploy/"
+          otafile = data['payload'][0]['otafiles']
+          rebootneeded = True
+          message = DEVICE_NAME + " OTA: " + otafile
+          try:
+              ota_updater = OTAUpdater(firmware_url, otafile)
+              if ota_updater.check_for_updates():
+                  if ota_updater.download_and_install_update():
+                    message += " updated"
+                  else:
+                    message += " update failed"
+              else:
+                  message += " up-to-date"        
+                  rebootneeded = False
+          except Exception as err:
+              message += " err:" + str(err) + " type:" + str(type(err))
+          
+          finally:
+              print(message)
+              client.publish(SPARKPLUGB_DATA_TOPIC, message)
+              if rebootneeded:
+                  reboot_with_reason(client, DDEATH_REASON_OTA)
+      elif "\"cmdID\":\"status\"" in message:
+          #print('ESP received CMD message: status')
+          client.publish(topic_pub_b, create_sensor_message())
+      elif "\"cmdID\":\"reset\"" in message:
+          #print('ESP received CMD message: reboot')
+          reboot_with_reason(client, DDEATH_REASON_DCMD_REBOOT)
 
 def connect_and_subscribe():
-  global client_id, mqtt_server, topic_sub
-  client = MQTTClient(client_id, mqtt_server)
+  global client_id_b, topic_cmd_b
+  client = MQTTClient(client_id_b, MQTT_BROKER_ADD)
   client.set_callback(sub_cb)
+  message = get_sparkplug_prefx() + ",\"ddeath_reasons\": \"-1\"}"
+  client.set_last_will(SPARKPLUGB_DEATH_TOPIC, message.encode())
   client.connect()
-  client.subscribe(topic_sub)
-  print('Connected to %s MQTT broker, subscribed to %s topic' % (mqtt_server, topic_sub))
+  client.subscribe(topic_cmd_b)
+  birthmessage = get_sparkplug_prefx() + "}"
+  client.publish(SPARKPLUGB_BIRTHTH_TOPIC.encode(), birthmessage.encode())
+  #print('Connected to %s MQTT broker, subscribed to %s topic' % (MQTT_BROKER_ADD, topic_cmd_b))
   return client
 
 def restart_and_reconnect():
-  print('Failed to connect to MQTT broker. Reconnecting...')
+  #print('Failed to connect to MQTT broker. Reconnecting...')
   time.sleep(10)
   machine.reset()
 
@@ -100,7 +111,7 @@ def create_sensor_message(error = ""):
     global analogSensor
     global digitalSensor
 
-    message = "{\"devNm\":\"" + DEVICE_NAME + "\",\"devTy\":\"" + DEVICE_TYPE + "\",\"AP\":\"" + SSID + "\""
+    message = get_sparkplug_prefx() + ",\"devNm\":\"" + DEVICE_NAME + "\",\"devTy\":\"" + DEVICE_TYPE + "\",\"AP\":\"" + SSID + "\""
     if (analogSensor != ""):
         message = message + ",\"AnaR\":\"" + str(analogSensor.read()) + "\""
     if (digitalSensor != ""):
@@ -109,16 +120,31 @@ def create_sensor_message(error = ""):
         message = message + ",\"err\":\"" + error + "\""
     return message + "}"
 
+# Main program
+
+# Init sensors
+analogSensor = ""
+if ANALOG_SENSOR_PIN != "":
+    from machine import ADC
+    analogSensor = ADC(ANALOG_SENSOR_PIN)
+
+digitalSensor = ""
+if DIGITAL_SENSOR_PIN != "":
+    from machine import Pin
+    digitalSensor = Pin(DIGITAL_SENSOR_PIN, Pin.IN, Pin.PULL_UP)
+
+# Connect to MQTT broker and subscribe to command topic
 try:
   client = connect_and_subscribe()
 except OSError as e:
   restart_and_reconnect()
 
+last_message = 0
 while True:
   try:
     client.check_msg()
-    if (time.time() - last_message) > message_interval:
-      client.publish(topic_pub, create_sensor_message())
+    if (time.time() - last_message) > MQTT_PUBLISH_INTERVAL:
+      client.publish(topic_pub_b, create_sensor_message().encode())
       last_message = time.time()
-  except OSError as e:
+  except Exception as e:
     restart_and_reconnect()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,7 @@
 VERSION = "1.0"
 import gc
+from machine import RTC
+import ntptime
 
 def qs_parse(qs):
  
@@ -24,3 +26,15 @@ def free(full=False):
   P = '{0:.2f}%'.format(F/T*100)
   if not full: return P
   else : return ('Total:{0} Free:{1} ({2})'.format(T,F,P))
+
+def get_epoch_time():
+
+    try:
+        ntptime.settime()  # Synchronize with NTP server
+        rtc = RTC()
+        t = rtc.datetime()
+        epoch_time = (t[0]-1970) * 31536000 + t[1] * 2628000 + t[2] * 86400 + t[3] * 3600 + t[4] * 60 + t[5]
+        return epoch_time
+    except OSError:
+        print("Error: Could not synchronize with NTP server.")
+        return None


### PR DESCRIPTION
Refactor: OTA and Status Commands via Single DCMD Topic
Only changed main_mqtt2.py, other /deploy files changes seems to be variations of minifying.
Replaced the generic 'OTA/OTARequest' topic with a more flexible approach using a single DCMD topic for various commands.

-   Commands are now passed as a JSON payload within the  `pBv1.0/flood_sensors/DCMD`  topic, using the  `name`  field to specify the command ('OTA' or 'status').
-   'OTA' command triggers an over-the-air update and publishes progress updates.
-   'status' command triggers an immediate status message publication, supporting event-driven updates instead of polling.
-  Need to figure out if status should be responded to by individual sensors or all sensors.
